### PR TITLE
feat(static): add SPA serving via SPA and SPAFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Key goals:
 - **Auto-Generated OpenAPI Docs** – Swagger UI, ReDoc, and Scalar automatically synced with your code.
 - **Runtime Documentation Control** – Enable/disable OpenAPI docs at runtime without redeployment
 - **Authentication Ready** – Native JWT, Basic Auth, and extensible middleware support.
+- **SPA Serving** – Serve single-page apps (React, Vue, …) with index fallback, from disk or an embedded filesystem.
 - **Standard Library Compatible** – Fully compatible with Go’s `net/http`.
 - **Dynamic Route Management** – Enable/disable routes at runtime without code changes
 - **Production Ready** –  TLS support, CORS, graceful shutdown, middleware system, and more.
@@ -364,6 +365,51 @@ func main() {
     app.Start()
 }
 ```
+
+---
+
+## Single-Page Applications
+
+Serve a client-side routed app (React, Vue, Svelte, …) alongside your API.
+
+Register the SPA after your API routes.
+
+```go
+func main() {
+    o := okapi.Default()
+
+    o.Get("/api/v1/users", listUsers)
+
+    // From disk 
+    o.SPA("/", "./web")
+
+    o.Start()
+}
+```
+
+For single-binary deployments, embed the built front-end and serve it with
+`SPAFS`:
+
+```go
+//go:embed all:web/dist
+var dist embed.FS
+
+func main() {
+    o := okapi.Default()
+
+    o.Get("/api/v1/users", listUsers)
+
+    o.SPAFS("/", dist, okapi.SPAConfig{
+        Root:   "web/dist", // sub-directory inside the embed.FS
+        MaxAge: time.Hour,  // Cache-Control for assets; index stays no-cache
+    })
+
+    o.Start()
+}
+```
+
+See the [SPA guide](https://okapi.jkaninda.dev/features/spa.html) and the
+[`examples/spa`](examples/spa) example for the full configuration.
 
 ---
 

--- a/constants.go
+++ b/constants.go
@@ -33,6 +33,7 @@ const (
 	constLocationHeader    = "Location"
 	okapiName              = "Okapi"
 	constTRUE              = "true"
+	constIndex             = "index.html"
 
 	openApiVersion                     = "3.0.3"
 	openApiVersion31                   = "3.1.0"

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -2,7 +2,7 @@
 title: CLI
 layout: default
 parent: Features
-nav_order: 9
+nav_order: 10
 ---
 
 # CLI Integration

--- a/docs/features/client.md
+++ b/docs/features/client.md
@@ -2,7 +2,7 @@
 title: HTTP Client
 layout: default
 parent: Features
-nav_order: 13
+nav_order: 14
 ---
 
 # HTTP Client

--- a/docs/features/error-hanling.md
+++ b/docs/features/error-hanling.md
@@ -2,7 +2,7 @@
 title: Error Handling
 layout: default
 parent: Features
-nav_order: 10
+nav_order: 11
 ---
 
 # Error Handling

--- a/docs/features/spa.md
+++ b/docs/features/spa.md
@@ -1,0 +1,107 @@
+---
+title: Single-Page Applications
+layout: default
+parent: Features
+nav_order: 7
+---
+
+# Single-Page Applications (SPA)
+
+Okapi can serve a single-page application (React, Vue, Svelte, Angular, …)
+alongside your API. Real files (the index document, JS, CSS, images) are
+served directly, and any unmatched path falls back to the SPA index so the
+client-side router can take over.
+
+Two entry points are provided:
+
+- `SPA(prefix, dir)` — serve from a directory on disk.
+- `SPAFS(prefix, fsys)` — serve from any `fs.FS`, including an `embed.FS`
+  for single-binary deployments.
+
+Register the SPA **after** your API routes so the API keeps precedence.
+
+## Serve from disk
+
+Useful during front-end development:
+
+```go
+func main() {
+    o := okapi.Default()
+
+    o.Get("/api/v1/users", listUsers)
+
+    // Serves ./web/index.html for "/", "/login", "/users/42", ...
+    o.SPA("/", "./web")
+
+    o.Start()
+}
+```
+
+## Serve from an embedded filesystem
+
+The recommended approach for production — the whole front-end ships inside
+the binary:
+
+```go
+//go:embed all:web/dist
+var dist embed.FS
+
+func main() {
+    o := okapi.Default()
+
+    o.Get("/api/v1/users", listUsers)
+
+    o.SPAFS("/", dist, okapi.SPAConfig{
+        Root:   "web/dist", // sub-directory inside the embed.FS
+        MaxAge: time.Hour,  // Cache-Control for assets
+    })
+
+    o.Start()
+}
+```
+
+## How routing works
+
+For every unmatched `GET`/`HEAD` request under the prefix:
+
+1. If the path maps to a real file, that file is served.
+2. Otherwise the SPA index document is returned so the client-side router
+   can handle the route.
+
+Registered API routes always win the match. In addition, the top-level path
+segment of every registered route is **auto-excluded** from the fallback, so
+an unknown path under an API namespace returns `404` instead of silently
+serving the index. For example, with `/api/v1/users` registered,
+`/api/v1/missing` returns `404` rather than `index.html`.
+
+## Caching
+
+- The **index document** is always served with `Cache-Control: no-cache`, so
+  a new deploy is picked up immediately.
+- **Asset files** honour `SPAConfig.MaxAge`. With `MaxAge: time.Hour`, assets
+  are served with `Cache-Control: public, max-age=3600`. When `MaxAge` is
+  zero, no `Cache-Control` header is added for assets.
+
+## Configuration
+
+`SPAConfig` is optional — the zero value serves `index.html` and
+auto-excludes registered API routes.
+
+| Field | Description |
+| --- | --- |
+| `Index` | File served for client-side routes. Defaults to `index.html`. |
+| `Root` | Sub-directory inside the `fs.FS` that holds the built SPA (`SPAFS` only). |
+| `Exclude` | Additional path prefixes that must never fall back to the index. |
+| `DisableAutoExclude` | Turn off auto-excluding registered route segments; only `Exclude` is consulted. |
+| `MaxAge` | `Cache-Control` max-age for asset files. The index is always `no-cache`. |
+
+### Excluding extra paths
+
+```go
+o.SPA("/", "./web", okapi.SPAConfig{
+    Exclude: []string{"/metrics", "/healthz"},
+})
+```
+
+A full, runnable example lives in
+[`examples/spa`](https://github.com/jkaninda/okapi/tree/main/examples/spa).

--- a/docs/features/std-lib-compatibility.md
+++ b/docs/features/std-lib-compatibility.md
@@ -2,7 +2,7 @@
 title: Standard Library Compatibility
 layout: default
 parent: Features
-nav_order: 11
+nav_order: 12
 ---
 
 # Standard Library Compatibility

--- a/docs/features/templating.md
+++ b/docs/features/templating.md
@@ -190,3 +190,8 @@ app.StaticFS("/assets", AssetsFS)
 ```
 
 This pairs naturally with the [Embedded Templates](#embedded-templates) example above, where `AssetsFS` is derived from the same `embed.FS`.
+
+### Serve a single-page application
+
+To serve a client-side routed app (React, Vue, …) with index fallback, use
+`SPA` / `SPAFS` instead of `Static`. See [Single-Page Applications](spa.md).

--- a/docs/features/testing.md
+++ b/docs/features/testing.md
@@ -2,7 +2,7 @@
 title: Testing
 layout: default
 parent: Features
-nav_order: 8
+nav_order: 9
 ---
 
 # Testing

--- a/docs/features/tls-https.md
+++ b/docs/features/tls-https.md
@@ -2,7 +2,7 @@
 title: TLS & HTTPS
 layout: default
 parent: Features
-nav_order: 7
+nav_order: 8
 ---
 
 # TLS & HTTPS

--- a/docs/features/websocket.md
+++ b/docs/features/websocket.md
@@ -2,7 +2,7 @@
 title: WebSocket
 layout: default
 parent: Features
-nav_order: 12
+nav_order: 13
 ---
 # WebSocket
 Okapi provides WebSocket support through the `okapiws` package, enabling real-time, bidirectional communication between server and clients. This lightweight, framework-agnostic package offers a clean API and seamless integration with both Okapi and standard Go HTTP servers.

--- a/examples/spa/main.go
+++ b/examples/spa/main.go
@@ -1,0 +1,96 @@
+/*
+ *  MIT License
+ *
+ * Copyright (c) 2025 Jonas Kaninda
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package main
+
+import (
+	"embed"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/jkaninda/okapi"
+)
+
+//go:embed all:web
+var webFS embed.FS
+
+type User struct {
+	ID    int    `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+var users = []User{
+	{ID: 1, Name: "Jonas", Email: "jonas@example.com"},
+	{ID: 2, Name: "Sam", Email: "sam@example.com"},
+	{ID: 3, Name: "Josh", Email: "josh@example.com"},
+}
+
+func main() {
+	o := okapi.Default()
+
+	api := o.Group("/api/v1")
+	api.Get("/health", func(c *okapi.Context) error {
+		return c.OK(okapi.M{"status": "ok"})
+	})
+
+	// List all users.
+	api.Get("/users", func(c *okapi.Context) error {
+		return c.OK(okapi.M{"users": users})
+	})
+
+	// Get a single user by ID
+	api.Get("/users/:id", func(c *okapi.Context) error {
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, okapi.M{"error": "invalid user id"})
+		}
+		for _, u := range users {
+			if u.ID == id {
+				return c.OK(u)
+			}
+		}
+		return c.JSON(http.StatusNotFound, okapi.M{"error": "user not found"})
+	})
+
+	// Serve the SPA. Real files (index.html, assets/*) are served directly
+
+	// any other path falls back to index.html so the client-side router takes
+	// over. Try "/", "/dashboard", "/users/2".
+	// Embedded (single binary) — recommended for deployments:
+	o.SPAFS("/", webFS, okapi.SPAConfig{
+		Root:   "web",     // sub-directory inside the embed.FS
+		MaxAge: time.Hour, // Cache-Control for assets; index.html stays no-cache
+	})
+
+	// From disk — during front-end development:
+	//
+	//	o.SPA("/", "./web", okapi.SPAConfig{MaxAge: time.Hour})
+
+	// Visit http://localhost:8080
+	if err := o.Start(); err != nil {
+		panic(err)
+	}
+}

--- a/examples/spa/web/assets/app.js
+++ b/examples/spa/web/assets/app.js
@@ -1,0 +1,35 @@
+function render() {
+  document.getElementById('route').textContent = 'Current route: ' + location.pathname;
+}
+
+document.addEventListener('click', (e) => {
+  const link = e.target.closest('a[data-link]');
+  if (!link) return;
+  e.preventDefault();
+  history.pushState(null, '', link.getAttribute('href'));
+  render();
+});
+
+window.addEventListener('popstate', render);
+
+// Render the full list of users (name + email) into the <ul>.
+document.getElementById('load-users').addEventListener('click', async () => {
+  const res = await fetch('/api/v1/users');
+  const { users } = await res.json();
+  const list = document.getElementById('users');
+  list.innerHTML = '';
+  for (const u of users) {
+    const li = document.createElement('li');
+    li.textContent = `#${u.id} — ${u.name} <${u.email}>`;
+    list.appendChild(li);
+  }
+});
+
+// Look up a single user by ID and show the raw JSON response.
+document.getElementById('find-user').addEventListener('click', async () => {
+  const id = document.getElementById('user-id').value;
+  const res = await fetch(`/api/v1/users/${id}`);
+  document.getElementById('out').textContent = JSON.stringify(await res.json(), null, 2);
+});
+
+render();

--- a/examples/spa/web/assets/style.css
+++ b/examples/spa/web/assets/style.css
@@ -1,0 +1,43 @@
+body {
+  font-family: system-ui, sans-serif;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  background: #1b1f28;
+  color: #e2e8f0;
+}
+
+main {
+  text-align: center;
+  max-width: 32rem;
+  padding: 2rem;
+}
+
+nav {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin: 1rem 0;
+}
+
+a {
+  color: #38bdf8;
+}
+
+button {
+  background: #38bdf8;
+  border: 0;
+  border-radius: 0.5rem;
+  padding: 0.6rem 1rem;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+pre {
+  text-align: left;
+  background: #1e293b;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  overflow: auto;
+}

--- a/examples/spa/web/index.html
+++ b/examples/spa/web/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Okapi SPA Example</title>
+  <link rel="stylesheet" href="/assets/style.css" />
+</head>
+<body>
+  <main>
+    <h1>Okapi SPA</h1>
+    <p id="route"></p>
+    <nav>
+      <a href="/" data-link>Home</a>
+      <a href="/dashboard" data-link>Dashboard</a>
+      <a href="/users/1" data-link>User 1</a>
+    </nav>
+
+    <section>
+      <h2>Users</h2>
+      <button id="load-users">Load users</button>
+      <ul id="users"></ul>
+    </section>
+
+    <section>
+      <h2>Find user by ID</h2>
+      <input id="user-id" type="number" min="1" value="1" />
+      <button id="find-user">Find</button>
+      <pre id="out"></pre>
+    </section>
+  </main>
+  <script src="/assets/app.js"></script>
+</body>
+</html>

--- a/static.go
+++ b/static.go
@@ -28,6 +28,9 @@ import (
 	"io/fs"
 	"net/http"
 	"path"
+	"strconv"
+	"strings"
+	"time"
 )
 
 // noDirListing wraps http.FileSystem to disable directory listing
@@ -54,4 +57,178 @@ func (n noDirListing) Open(name string) (http.File, error) {
 		}
 	}
 	return f, nil
+}
+
+// SPAConfig configures how a single-page application (SPA) is served by
+// Okapi.SPA and Okapi.SPAFS. The zero value is valid and produces sensible
+// defaults (serve index.html, auto-exclude registered API routes).
+type SPAConfig struct {
+	// Index is the file served for client-side routes that do not map to a
+	// real file on disk. Defaults to "index.html".
+	Index string
+
+	// Root is the sub-directory inside the http.FileSystem / fs.FS that holds
+	// the built SPA. It is only used by SPAFS (e.g. "web/dist" for an
+	// embed.FS rooted at the module). Ignored by SPA.
+	Root string
+
+	// Exclude lists additional path prefixes that must never fall back to the
+	// SPA index.
+	Exclude []string
+
+	// DisableAutoExclude turns off the default behaviour of excluding the
+	// top-level segment of every registered route from the SPA fallback. When
+	// true, only Exclude is consulted.
+	DisableAutoExclude bool
+
+	// MaxAge sets the Cache-Control max-age for real asset files (JS, CSS,
+	// images...). The SPA index document is always served with "no-cache" so a
+	// new deploy is picked up immediately. Zero means no Cache-Control header
+	// is added for assets.
+	MaxAge time.Duration
+}
+
+func resolveSPAConfig(cfg ...SPAConfig) SPAConfig {
+	c := SPAConfig{}
+	if len(cfg) > 0 {
+		c = cfg[0]
+	}
+	if c.Index == "" {
+		c.Index = constIndex
+	}
+	return c
+}
+
+// SPA serves a single-page application from a directory on disk.
+//
+// Real files (assets, the index, etc.) are served directly; any unmatched
+// path that is not excluded falls back to the SPA index document so the
+// client-side router can take over. Registered API routes keep precedence,
+// and their top-level path segments are excluded from the fallback
+// automatically (see SPAConfig.DisableAutoExclude).
+//
+// SPA should be registered after your API routes so they win the match.
+//
+// Example:
+//
+//	app.Get("/api/v1/users", listUsers)
+//	app.SPA("/", "./web") // serves ./web/index.html for "/", "/login", ...
+func (o *Okapi) SPA(prefix, dir string, cfg ...SPAConfig) {
+	o.spaHandler(prefix, http.Dir(dir), resolveSPAConfig(cfg...))
+}
+
+// SPAFS serves a single-page application from an fs.FS.
+//
+// Example:
+//
+//	//go:embed all:web/dist
+//	var dist embed.FS
+//
+//	app.Get("/api/v1/users", listUsers)
+//	app.SPAFS("/", dist, okapi.SPAConfig{Root: "web/dist"})
+func (o *Okapi) SPAFS(prefix string, fsys fs.FS, cfg ...SPAConfig) {
+	c := resolveSPAConfig(cfg...)
+	if c.Root != "" {
+		if sub, err := fs.Sub(fsys, c.Root); err == nil {
+			fsys = sub
+		}
+	}
+	o.spaHandler(prefix, http.FS(fsys), c)
+}
+
+// spaHandler registers the SPA fallback handler under prefix.
+func (o *Okapi) spaHandler(prefix string, root http.FileSystem, c SPAConfig) {
+	if prefix == "" {
+		prefix = "/"
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if o.spaExcluded(r.URL.Path, prefix, c) {
+			o.spaNotFound(w, r)
+			return
+		}
+
+		rel := strings.TrimPrefix(r.URL.Path, strings.TrimSuffix(prefix, "/"))
+		clean := path.Clean("/" + strings.TrimPrefix(rel, "/"))
+
+		if clean != "/" && serveSPAFile(w, r, root, clean, c.MaxAge) {
+			return
+		}
+		serveSPAIndex(w, r, root, c.Index)
+	}
+	o.router.muxRouter.PathPrefix(prefix).
+		HandlerFunc(handler).
+		Methods(http.MethodGet, http.MethodHead)
+}
+
+func (o *Okapi) spaExcluded(urlPath, prefix string, c SPAConfig) bool {
+	for _, ex := range c.Exclude {
+		ex = strings.TrimSuffix(ex, "/")
+		if ex != "" && (urlPath == ex || strings.HasPrefix(urlPath, ex+"/")) {
+			return true
+		}
+	}
+	if c.DisableAutoExclude {
+		return false
+	}
+	seg := firstPathSegment(urlPath)
+	if seg == "" || seg == firstPathSegment(prefix) {
+		return false
+	}
+	for _, rt := range o.routes {
+		if firstPathSegment(rt.Path) == seg {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *Okapi) spaNotFound(w http.ResponseWriter, r *http.Request) {
+	if h := o.router.muxRouter.NotFoundHandler; h != nil {
+		h.ServeHTTP(w, r)
+		return
+	}
+	http.NotFound(w, r)
+}
+
+func serveSPAFile(w http.ResponseWriter, r *http.Request, root http.FileSystem, name string, maxAge time.Duration) bool {
+	f, err := root.Open(name)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+
+	stat, err := f.Stat()
+	if err != nil || stat.IsDir() {
+		return false
+	}
+	if maxAge > 0 {
+		w.Header().Set("Cache-Control", "public, max-age="+strconv.Itoa(int(maxAge.Seconds())))
+	}
+	http.ServeContent(w, r, stat.Name(), stat.ModTime(), f)
+	return true
+}
+
+func serveSPAIndex(w http.ResponseWriter, r *http.Request, root http.FileSystem, index string) {
+	f, err := root.Open("/" + strings.TrimPrefix(index, "/"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	stat, err := f.Stat()
+	if err != nil || stat.IsDir() {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-cache")
+	http.ServeContent(w, r, stat.Name(), stat.ModTime(), f)
+}
+
+func firstPathSegment(p string) string {
+	p = strings.TrimPrefix(p, "/")
+	if i := strings.IndexByte(p, '/'); i >= 0 {
+		return p[:i]
+	}
+	return p
 }

--- a/static_test.go
+++ b/static_test.go
@@ -1,0 +1,144 @@
+package okapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeSPAFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "assets"), 0o755); err != nil {
+		t.Fatalf("mkdir assets: %v", err)
+	}
+	files := map[string]string{
+		"index.html":    "<!doctype html><title>app</title>",
+		"assets/app.js": "console.log('hi')",
+		"favicon.ico":   "icon",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, filepath.FromSlash(name)), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+func serveSPARequest(o *Okapi, target string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rec := httptest.NewRecorder()
+	o.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestSPAServesRealFile(t *testing.T) {
+	dir := writeSPAFixture(t)
+	o := New()
+	o.SPA("/", dir)
+
+	rec := serveSPARequest(o, "/assets/app.js")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("asset status = %d, want 200", rec.Code)
+	}
+	if rec.Body.String() != "console.log('hi')" {
+		t.Fatalf("asset body = %q", rec.Body.String())
+	}
+}
+
+func TestSPAFallsBackToIndex(t *testing.T) {
+	dir := writeSPAFixture(t)
+	o := New()
+	o.SPA("/", dir)
+
+	for _, p := range []string{"/", "/login", "/users/42/profile"} {
+		rec := serveSPARequest(o, p)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want 200", p, rec.Code)
+		}
+		if rec.Body.String() != "<!doctype html><title>app</title>" {
+			t.Fatalf("%s did not return the SPA index: %q", p, rec.Body.String())
+		}
+		if cc := rec.Header().Get("Cache-Control"); cc != "no-cache" {
+			t.Fatalf("%s Cache-Control = %q, want no-cache", p, cc)
+		}
+	}
+}
+
+func TestSPAAutoExcludesRegisteredRoutes(t *testing.T) {
+	dir := writeSPAFixture(t)
+	o := New()
+	o.Get("/api/v1/users", func(c *Context) error { return c.OK(M{"ok": true}) })
+	o.SPA("/", dir)
+
+	if rec := serveSPARequest(o, "/api/v1/users"); rec.Code != http.StatusOK {
+		t.Fatalf("registered route status = %d, want 200", rec.Code)
+	}
+	// An unmatched path under the same namespace 404s instead of serving index.
+	rec := serveSPARequest(o, "/api/v1/does-not-exist")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unmatched api path status = %d, want 404", rec.Code)
+	}
+}
+
+func TestSPAExcludeOption(t *testing.T) {
+	dir := writeSPAFixture(t)
+	o := New()
+	o.SPA("/", dir, SPAConfig{Exclude: []string{"/metrics"}})
+
+	rec := serveSPARequest(o, "/metrics")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("excluded path status = %d, want 404", rec.Code)
+	}
+	// A normal SPA route is unaffected.
+	if rec := serveSPARequest(o, "/dashboard"); rec.Code != http.StatusOK {
+		t.Fatalf("spa route status = %d, want 200", rec.Code)
+	}
+}
+
+func TestSPAFSFromFilesystem(t *testing.T) {
+	dir := writeSPAFixture(t)
+	o := New()
+	o.SPAFS("/", os.DirFS(dir))
+
+	if rec := serveSPARequest(o, "/assets/app.js"); rec.Code != http.StatusOK {
+		t.Fatalf("fs asset status = %d, want 200", rec.Code)
+	}
+	rec := serveSPARequest(o, "/some/client/route")
+	if rec.Code != http.StatusOK || rec.Body.String() != "<!doctype html><title>app</title>" {
+		t.Fatalf("fs fallback failed: status=%d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSPACustomIndexAndCache(t *testing.T) {
+	dir := writeSPAFixture(t)
+	o := New()
+	o.SPA("/", dir, SPAConfig{MaxAge: time.Hour})
+
+	// Index is no-cache.
+	if cc := serveSPARequest(o, "/route").Header().Get("Cache-Control"); cc != "no-cache" {
+		t.Fatalf("index Cache-Control = %q, want no-cache", cc)
+	}
+	// Real assets get the configured max-age.
+	if cc := serveSPARequest(o, "/assets/app.js").Header().Get("Cache-Control"); cc != "public, max-age=3600" {
+		t.Fatalf("asset Cache-Control = %q, want public, max-age=3600 (1h)", cc)
+	}
+}
+
+func TestFirstPathSegment(t *testing.T) {
+	cases := map[string]string{
+		"/":             "",
+		"/api":          "api",
+		"/api/v1/users": "api",
+		"api/v1":        "api",
+		"/{any:.*}":     "{any:.*}",
+	}
+	for in, want := range cases {
+		if got := firstPathSegment(in); got != want {
+			t.Errorf("firstPathSegment(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Add first-class single-page application support so client-side routed apps can be served alongside API routes.