### PR TITLE
fix(spa): register OpenAPI docs routes before the SPA fallback

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -211,62 +211,65 @@ func (o *Okapi) registerDocRoutes() {
 	}
 	o.docRoutesRegistered = true
 	o.openApiEnabled = true
-	enabled := func(h HandlerFunc) HandlerFunc {
-		return func(c *Context) error {
-			if !o.openApiEnabled {
-				return c.AbortNotFound("Not Found")
-			}
-			return h(c)
+
+	enabled := func(c *Context) error {
+		if !o.openApiEnabled {
+			return c.AbortNotFound("Not Found")
 		}
+		return c.Next()
 	}
-	strict := func(h HandlerFunc) HandlerFunc {
-		return enabled(func(c *Context) error {
-			if o.openAPI.StrictDocUI {
-				return c.AbortNotFound("Not Found")
-			}
-			return h(c)
-		})
+
+	strict := func(c *Context) error {
+		if o.openAPI.StrictDocUI {
+			return c.AbortNotFound("Not Found")
+		}
+		return c.Next()
+	}
+
+	doc := func(path string, h HandlerFunc, mw ...Middleware) {
+		route := o.Get(path, h)
+		route.internalRoute().Hide() // Hide the route from the OpenAPI documentation
+		route.Use(mw...)
 	}
 
 	// Default favicon endpoint, suppressed when a custom favicon is configured.
-	o.Get(docFaviconPath, enabled(func(c *Context) error {
+	doc(docFaviconPath, func(c *Context) error {
 		if o.openAPI.Favicon != "" {
 			return c.AbortNotFound("Not Found")
 		}
 		return c.Data(http.StatusOK, "image/png", okapiFavicon)
-	})).internalRoute().Hide()
+	}, enabled)
 	// Default OpenAPI routes serve the latest version (3.1).
-	o.Get(openApiDocPath, enabled(func(c *Context) error {
+	doc(openApiDocPath, func(c *Context) error {
 		return c.JSON(http.StatusOK, o.openapiSpec31)
-	})).internalRoute().Hide() // Hide the route from the OpenAPI documentation
-	o.Get(openApiYamlPath, enabled(func(c *Context) error {
+	}, enabled)
+	doc(openApiYamlPath, func(c *Context) error {
 		return c.YAML(http.StatusOK, o.openapiSpec31)
-	})).internalRoute().Hide()
+	}, enabled)
 	// Version-pinned OpenAPI 3.0 routes
-	o.Get(openApiDocPath30, enabled(func(c *Context) error {
+	doc(openApiDocPath30, func(c *Context) error {
 		return c.JSON(http.StatusOK, o.openapiSpec)
-	})).internalRoute().Hide()
-	o.Get(openApiYamlPath30, enabled(func(c *Context) error {
+	}, enabled)
+	doc(openApiYamlPath30, func(c *Context) error {
 		return c.YAML(http.StatusOK, o.openapiSpec)
-	})).internalRoute().Hide()
-	// Register the main docs route.
-	o.Get(openApiDocPrefix, enabled(func(c *Context) error {
+	}, enabled)
+	// Main docs route.
+	doc(openApiDocPrefix, func(c *Context) error {
 		return c.renderHTML(http.StatusOK, o.docsTemplate(), o.docData())
-	})).internalRoute().Hide() // Hide the route from the OpenAPI documentation
+	}, enabled)
 	// TODO: remove this route in the next major release
-	o.Get("/docs/index.html", enabled(func(c *Context) error {
+	doc("/docs/index.html", func(c *Context) error {
 		return c.renderHTML(http.StatusOK, o.docsTemplate(), o.docData())
-	})).internalRoute().Hide()
+	}, enabled)
 
-	// Register the Swagger UI route
-	o.Get(docSwaggerPath, strict(func(c *Context) error {
+	// Dedicated UI routes additionally respect StrictDocUI.
+	doc(docSwaggerPath, func(c *Context) error {
 		return c.renderHTML(http.StatusOK, swaggerTemplate, o.docData())
-	})).internalRoute().Hide()
-	// Register the Redoc route
-	o.Get(docRedocPath, strict(func(c *Context) error {
+	}, enabled, strict)
+	doc(docRedocPath, func(c *Context) error {
 		return c.renderHTML(http.StatusOK, redocTemplate, o.docData())
-	})).internalRoute().Hide()
-	o.Get(docScalarPath, strict(func(c *Context) error {
+	}, enabled, strict)
+	doc(docScalarPath, func(c *Context) error {
 		return c.renderHTML(http.StatusOK, scalarTemplate, o.docData())
-	})).internalRoute().Hide()
+	}, enabled, strict)
 }

--- a/doc.go
+++ b/doc.go
@@ -196,57 +196,77 @@ func (o *Okapi) docsTemplate() *template.Template {
 	}
 }
 
-// registerDocRoutes registers the OpenAPI documentation routes for the Okapi instance.
-func (o *Okapi) registerDocRoutes(title string) {
+func (o *Okapi) docData() M {
 	favicon := o.openAPI.Favicon
 	if favicon == "" {
 		favicon = docFaviconPath
-		o.Get(docFaviconPath, func(c *Context) error {
-			return c.Data(http.StatusOK, "image/png", okapiFavicon)
-		}).internalRoute().Hide()
 	}
-	docData := M{"Title": title, "Favicon": favicon}
-	// Default OpenAPI routes serve the latest version (3.1).
-	o.Get(openApiDocPath, func(c *Context) error {
-		return c.JSON(http.StatusOK, o.openapiSpec31)
-	}).internalRoute().Hide() // Hide the route from the OpenAPI documentation
-	o.Get(openApiYamlPath, func(c *Context) error {
-		return c.YAML(http.StatusOK, o.openapiSpec31)
-	}).internalRoute().Hide()
-	// Version-pinned OpenAPI 3.0 routes
-	o.Get(openApiDocPath30, func(c *Context) error {
-		return c.JSON(http.StatusOK, o.openapiSpec)
-	}).internalRoute().Hide()
-	o.Get(openApiYamlPath30, func(c *Context) error {
-		return c.YAML(http.StatusOK, o.openapiSpec)
-	}).internalRoute().Hide()
-	// Register the main docs route.
-	o.Get(openApiDocPrefix, func(c *Context) error {
-		return c.renderHTML(http.StatusOK, o.docsTemplate(), docData)
-	},
-	).internalRoute().Hide() // Hide the route from the OpenAPI documentation
-	// TODO: remove this route in the next major release
-	o.Get("/docs/index.html", func(c *Context) error {
-		return c.renderHTML(http.StatusOK, o.docsTemplate(), docData)
-	},
-	).internalRoute().Hide() // Hide the route from the OpenAPI documentation
+	return M{"Title": o.openAPI.Title, "Favicon": favicon}
+}
 
-	if o.openAPI.StrictDocUI {
+// registerDocRoutes registers the OpenAPI documentation routes for the Okapi instance.
+func (o *Okapi) registerDocRoutes() {
+	if o.docRoutesRegistered {
 		return
 	}
+	o.docRoutesRegistered = true
+	o.openApiEnabled = true
+	enabled := func(h HandlerFunc) HandlerFunc {
+		return func(c *Context) error {
+			if !o.openApiEnabled {
+				return c.AbortNotFound("Not Found")
+			}
+			return h(c)
+		}
+	}
+	strict := func(h HandlerFunc) HandlerFunc {
+		return enabled(func(c *Context) error {
+			if o.openAPI.StrictDocUI {
+				return c.AbortNotFound("Not Found")
+			}
+			return h(c)
+		})
+	}
+
+	// Default favicon endpoint, suppressed when a custom favicon is configured.
+	o.Get(docFaviconPath, enabled(func(c *Context) error {
+		if o.openAPI.Favicon != "" {
+			return c.AbortNotFound("Not Found")
+		}
+		return c.Data(http.StatusOK, "image/png", okapiFavicon)
+	})).internalRoute().Hide()
+	// Default OpenAPI routes serve the latest version (3.1).
+	o.Get(openApiDocPath, enabled(func(c *Context) error {
+		return c.JSON(http.StatusOK, o.openapiSpec31)
+	})).internalRoute().Hide() // Hide the route from the OpenAPI documentation
+	o.Get(openApiYamlPath, enabled(func(c *Context) error {
+		return c.YAML(http.StatusOK, o.openapiSpec31)
+	})).internalRoute().Hide()
+	// Version-pinned OpenAPI 3.0 routes
+	o.Get(openApiDocPath30, enabled(func(c *Context) error {
+		return c.JSON(http.StatusOK, o.openapiSpec)
+	})).internalRoute().Hide()
+	o.Get(openApiYamlPath30, enabled(func(c *Context) error {
+		return c.YAML(http.StatusOK, o.openapiSpec)
+	})).internalRoute().Hide()
+	// Register the main docs route.
+	o.Get(openApiDocPrefix, enabled(func(c *Context) error {
+		return c.renderHTML(http.StatusOK, o.docsTemplate(), o.docData())
+	})).internalRoute().Hide() // Hide the route from the OpenAPI documentation
+	// TODO: remove this route in the next major release
+	o.Get("/docs/index.html", enabled(func(c *Context) error {
+		return c.renderHTML(http.StatusOK, o.docsTemplate(), o.docData())
+	})).internalRoute().Hide()
+
 	// Register the Swagger UI route
-	o.Get(docSwaggerPath, func(c *Context) error {
-		return c.renderHTML(http.StatusOK, swaggerTemplate, docData)
-	},
-	).internalRoute().Hide() // Hide the route from the OpenAPI documentation
+	o.Get(docSwaggerPath, strict(func(c *Context) error {
+		return c.renderHTML(http.StatusOK, swaggerTemplate, o.docData())
+	})).internalRoute().Hide()
 	// Register the Redoc route
-	o.Get(docRedocPath, func(c *Context) error {
-		return c.renderHTML(http.StatusOK, redocTemplate, docData)
-	},
-	).internalRoute().Hide() // Hide the route from the OpenAPI documentation
-	// Register the Scalar route
-	o.Get(docScalarPath, func(c *Context) error {
-		return c.renderHTML(http.StatusOK, scalarTemplate, docData)
-	},
-	).internalRoute().Hide() // Hide the route from the OpenAPI documentation
+	o.Get(docRedocPath, strict(func(c *Context) error {
+		return c.renderHTML(http.StatusOK, redocTemplate, o.docData())
+	})).internalRoute().Hide()
+	o.Get(docScalarPath, strict(func(c *Context) error {
+		return c.renderHTML(http.StatusOK, scalarTemplate, o.docData())
+	})).internalRoute().Hide()
 }

--- a/doc_test.go
+++ b/doc_test.go
@@ -38,7 +38,7 @@ func TestRegisterDocRoutes(t *testing.T) {
 		return c.Text(http.StatusOK, "Hello World!")
 	})
 
-	o.registerDocRoutes(o.openAPI.Title)
+	o.registerDocRoutes()
 
 	// Start server in background
 	go func() {

--- a/okapi.go
+++ b/okapi.go
@@ -56,38 +56,39 @@ type (
 	// Okapi represents the core application structure of the framework,
 	// holding configuration, routers, middleware, server settings, and documentation components.
 	Okapi struct {
-		context            *Context
-		ctx                context.Context
-		router             *Router
-		middlewares        []Middleware
-		server             *http.Server
-		tlsServer          *http.Server
-		baseCancel         context.CancelFunc
-		tlsConfig          *tls.Config
-		tlsServerConfig    *tls.Config
-		withTlsServer      bool
-		tlsAddr            string
-		routes             []*Route
-		debug              bool
-		accessLog          bool
-		strictSlash        bool
-		logger             *slog.Logger
-		renderer           Renderer
-		corsEnabled        bool
-		cors               Cors
-		writeTimeout       int
-		readTimeout        int
-		idleTimeout        int
-		optionsRegistered  map[string]bool
-		openapiSpec        *openapi3.T
-		openapiSpec31      *openapi3.T
-		webhooks           []*Route
-		openAPI            *OpenAPI
-		openApiEnabled     bool
-		maxMultipartMemory int64 // Maximum memory for multipart forms
-		noRoute            HandlerFunc
-		noMethod           HandlerFunc
-		errorHandler       ErrorHandler
+		context             *Context
+		ctx                 context.Context
+		router              *Router
+		middlewares         []Middleware
+		server              *http.Server
+		tlsServer           *http.Server
+		baseCancel          context.CancelFunc
+		tlsConfig           *tls.Config
+		tlsServerConfig     *tls.Config
+		withTlsServer       bool
+		tlsAddr             string
+		routes              []*Route
+		debug               bool
+		accessLog           bool
+		strictSlash         bool
+		logger              *slog.Logger
+		renderer            Renderer
+		corsEnabled         bool
+		cors                Cors
+		writeTimeout        int
+		readTimeout         int
+		idleTimeout         int
+		optionsRegistered   map[string]bool
+		openapiSpec         *openapi3.T
+		openapiSpec31       *openapi3.T
+		webhooks            []*Route
+		openAPI             *OpenAPI
+		openApiEnabled      bool
+		docRoutesRegistered bool
+		maxMultipartMemory  int64 // Maximum memory for multipart forms
+		noRoute             HandlerFunc
+		noMethod            HandlerFunc
+		errorHandler        ErrorHandler
 	}
 
 	Router struct {
@@ -637,7 +638,7 @@ func (o *Okapi) WithOpenAPIDocs(cfg ...OpenAPI) *Okapi {
 
 	o.buildOpenAPISpec()
 	// Register the OpenAPI JSON and Swagger UI routes
-	o.registerDocRoutes(o.openAPI.Title)
+	o.registerDocRoutes()
 	return o
 }
 
@@ -791,15 +792,7 @@ func New(options ...OptionFunc) *Okapi {
 
 // Default creates a new Okapi instance with default settings.
 func Default() *Okapi {
-	return New(
-		withDefaultConfig(),
-	)
-}
-
-func withDefaultConfig() OptionFunc {
-	return func(o *Okapi) {
-		o.openApiEnabled = true
-	}
+	return New().WithOpenAPIDocs()
 }
 
 // With applies the provided options to the Okapi instance

--- a/static_test.go
+++ b/static_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/jkaninda/okapi/okapitest"
 )
 
 func writeSPAFixture(t *testing.T) string {
@@ -141,4 +143,22 @@ func TestFirstPathSegment(t *testing.T) {
 			t.Errorf("firstPathSegment(%q) = %q, want %q", in, got, want)
 		}
 	}
+}
+func TestSPA(t *testing.T) {
+	dir := writeSPAFixture(t)
+	ts := DefaultTestServer(t)
+
+	ts.Group("/api/v1")
+	ts.Get("/health", func(c *Context) error {
+		return c.OK(M{"status": "ok"})
+	})
+	ts.SPA("/", dir, SPAConfig{MaxAge: time.Hour})
+
+	okapitest.GET(t, ts.BaseURL+"/docs").
+		ExpectStatusOK()
+
+	okapitest.GET(t, ts.BaseURL+"/swagger").ExpectStatusOK().ExpectBodyContains("swagger-ui")
+	okapitest.GET(t, ts.BaseURL+"/redoc").ExpectStatusOK().ExpectBodyContains("redoc")
+	okapitest.GET(t, ts.BaseURL+"/scalar").ExpectStatusOK().ExpectBodyContains("@scalar/api-reference")
+
 }

--- a/tests.go
+++ b/tests.go
@@ -89,6 +89,22 @@ func NewTestServer(t TestingT) *TestServer {
 	}
 }
 
+func DefaultTestServer(t TestingT) *TestServer {
+	t.Helper()
+	o := Default()
+	o.applyCommon()
+	o.context.okapi = o
+	srv := httptest.NewServer(o)
+	t.Cleanup(srv.Close)
+
+	return &TestServer{
+		Okapi:       o,
+		BaseURL:     srv.URL,
+		t:           t,
+		httptestSrv: srv,
+	}
+}
+
 // NewTestServerWIthOkapi creates and starts Okapi test server.
 func NewTestServerWithOkapi(t TestingT, o *Okapi) *TestServer {
 	t.Helper()


### PR DESCRIPTION
The documentation endpoints (/docs, /openapi.json, /swagger, ...) were
unreachable when an SPA was served via SPA/SPAFS.