### PR TITLE
chore(deprecation): mark WithMuxRouter and Context.Params() as deprec…

### DIFF
--- a/context.go
+++ b/context.go
@@ -276,6 +276,8 @@ func (c *Context) Path() string {
 }
 
 // Params returns all URL path parameters as a map.
+//
+// Deprecated: use PathParam to retrieve individual path parameters instead.
 func (c *Context) Params() map[string]string {
 	return mux.Vars(c.request)
 }

--- a/okapi.go
+++ b/okapi.go
@@ -287,7 +287,11 @@ func (r *Route) Use(m ...Middleware) {
 
 // ****** OKAPI OPTIONS ******
 
-// WithMuxRouter sets the router for the Okapi instance
+// WithMuxRouter sets the router for the Okapi instance.
+//
+// Deprecated: injecting a custom *mux.Router is no longer supported; Okapi
+// manages its own router internally. This option will be removed in a future
+// release.
 func WithMuxRouter(router *mux.Router) OptionFunc {
 	return func(o *Okapi) {
 		if router != nil {


### PR DESCRIPTION
…ated