### PR TITLE
feat(jwt): support multiple token lookup sources

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -27,25 +27,56 @@ package okapi
 import (
 	"errors"
 	"fmt"
-	"github.com/golang-jwt/jwt/v5"
 	"strings"
 	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // ********** Helpers **********************
 
-// extractToken pulls the token from header, query or cookie
+// extractToken pulls the token from header, query or cookie.
+//
+// TokenLookup may combine multiple sources separated by commas; the first
+// source that yields a non-empty token wins. For example:
+//
+//	"header:Authorization,query:token,cookie:jwt"
 func (jwtAuth *JWTAuth) extractToken(c *Context) (string, error) {
 	tokenLookup := jwtAuth.TokenLookup
 	if tokenLookup == "" {
 		tokenLookup = "header:Authorization"
 	}
-	parts := strings.Split(tokenLookup, ":")
+
+	var lastErr error
+	for _, lookup := range strings.Split(tokenLookup, ",") {
+		lookup = strings.TrimSpace(lookup)
+		if lookup == "" {
+			continue
+		}
+		token, err := jwtAuth.extractTokenFrom(c, lookup)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if token != "" {
+			return token, nil
+		}
+	}
+
+	if lastErr != nil {
+		return "", lastErr
+	}
+	return "", nil
+}
+
+// extractTokenFrom pulls the token from a single "source:name" lookup.
+func (jwtAuth *JWTAuth) extractTokenFrom(c *Context, lookup string) (string, error) {
+	parts := strings.Split(lookup, ":")
 	if len(parts) != 2 {
 		return "", errors.New("invalid token lookup config")
 	}
 
-	source, name := parts[0], parts[1]
+	source, name := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
 	switch source {
 	case "header":
 		auth := c.request.Header.Get(name)

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -125,6 +125,35 @@ func TestExtractToken(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:   "combined lookup falls back to query",
+			lookup: "header:Authorization,query:token",
+			setup: func(req *http.Request) {
+				q := req.URL.Query()
+				q.Set("token", "from-query")
+				req.URL.RawQuery = q.Encode()
+			},
+			wantToken: "from-query",
+		},
+		{
+			name:   "combined lookup prefers first source",
+			lookup: "header:Authorization,query:token",
+			setup: func(req *http.Request) {
+				req.Header.Set("Authorization", "Bearer from-header")
+				q := req.URL.Query()
+				q.Set("token", "from-query")
+				req.URL.RawQuery = q.Encode()
+			},
+			wantToken: "from-header",
+		},
+		{
+			name:   "combined lookup falls back past missing cookie",
+			lookup: "cookie:jwt,header:Authorization",
+			setup: func(req *http.Request) {
+				req.Header.Set("Authorization", "Bearer from-header")
+			},
+			wantToken: "from-header",
+		},
+		{
 			name:    "invalid lookup format",
 			lookup:  "garbage",
 			setup:   func(req *http.Request) {},

--- a/middlewares.go
+++ b/middlewares.go
@@ -109,6 +109,11 @@ type (
 		//   - "header:Authorization" (default)
 		//   - "query:token"
 		//   - "cookie:jwt"
+		//
+		// Multiple sources can be combined with commas; they are tried in order and
+		// the first source that yields a non-empty token is used. For example:
+		//   - "header:Authorization,query:token"
+		//   - "header:Authorization,query:token,cookie:jwt"
 		TokenLookup string
 		// ContextKey is the key used to store the full validated JWT claims in the request context.
 		//


### PR DESCRIPTION
TokenLookup now accepts a comma-separated list of sources, tried in order until one yields a non-empty token. This allows falling back across header, query, and cookie, e.g:

    TokenLookup: "header:Authorization,query:token,cookie:jwt"