### PR TITLE
feat(validator): add conditional-required, substring, schema-annotation tags and new formats

### DIFF
--- a/binder.go
+++ b/binder.go
@@ -631,6 +631,9 @@ func validateStruct(v any) error {
 		if sf.Tag.Get(tagRequired) == constTRUE && isEmptyValue(field) {
 			return fmt.Errorf("field %s is required", sf.Name)
 		}
+		if checkConditionalRequired(val, field, sf) {
+			return fmt.Errorf("field %s is required", sf.Name)
+		}
 		for _, check := range fieldConstraintCheckers {
 			if err := check(field, sf); err != nil {
 				return fmt.Errorf("field %s: %w", sf.Name, err)

--- a/constants.go
+++ b/constants.go
@@ -97,6 +97,18 @@ const (
 	tagExclusiveMax  = "exclusiveMax"
 	tagMinProperties = "minProperties"
 	tagMaxProperties = "maxProperties"
+	tagContains      = "contains"
+	tagNotContains   = "notContains"
+
+	// Conditional required tags (runtime-only; depend on sibling field values).
+	tagRequiredIf      = "requiredIf"
+	tagRequiredWith    = "requiredWith"
+	tagRequiredWithout = "requiredWithout"
+
+	// Schema-side annotations mapped to OpenAPI keywords.
+	tagReadOnly  = "readOnly"
+	tagWriteOnly = "writeOnly"
+	tagNullable  = "nullable"
 
 	// extOkapiConst is an internal marker extension used to carry an OpenAPI 3.1
 	// `const` value on the version-agnostic base schema. It is promoted to a real
@@ -138,6 +150,14 @@ const (
 	formatUppercase    = "uppercase"
 	formatSlug         = "slug"
 	formatHexColor     = "hexcolor"
+	// additional formats
+	formatJSON      = "json"
+	formatJWT       = "jwt"
+	formatBase64URL = "base64url"
+	formatPort      = "port"
+	formatTimezone  = "timezone"
+	formatLatitude  = "latitude"
+	formatLongitude = "longitude"
 	// Special values
 	bodyValue = "body"
 	bodyField = "Body"

--- a/docs/features/validation.md
+++ b/docs/features/validation.md
@@ -33,10 +33,43 @@ Okapi provides declarative validation and automatic default value assignment usi
 | `string` / `[]string` | `const:"active"`               | Requires the field to equal a fixed value.               |
 | `string` / `[]string` | `format:"email"`               | Enables format validation (e.g. `email`, `uuid`, etc.).  |
 | `string` / `[]string` | `pattern:"^[a-zA-Z]+$"`        | Validates the field against a regular expression.        |
+| `string` / `[]string` | `contains:"@"`                 | Ensures the string contains the given substring.         |
+| `string` / `[]string` | `notContains:" "`              | Ensures the string does not contain the given substring. |
 
-> **Slices:** `enum`, `const`, `format`, and `pattern` apply to **each element** of a `[]string` field. Failures are reported per index, e.g. `element [2]: ...`.
+> **Slices:** `enum`, `const`, `format`, `pattern`, `contains`, and `notContains` apply to **each element** of a `[]string` field. Failures are reported per index, e.g. `element [2]: ...`.
 
-> **Empty values:** `enum`, `const`, `format`, and `pattern` skip empty strings — combine with `required:"true"` to also enforce presence.
+> **Empty values:** `enum`, `const`, `format`, `pattern`, `contains`, and `notContains` skip empty strings — combine with `required:"true"` to also enforce presence.
+
+### Conditional Required Tags
+
+These make a field's requiredness depend on **sibling fields** in the same struct. Referenced fields use their **Go field name**, not the JSON name.
+
+| Tag                            | Description                                                                   |
+|--------------------------------|-------------------------------------------------------------------------------|
+| `requiredIf:"Type card"`       | Required when the sibling field `Type` equals `card`.                         |
+| `requiredWith:"Pass"`          | Required when any of the listed sibling fields (comma-separated) is non-empty. |
+| `requiredWithout:"Email"`      | Required when any of the listed sibling fields (comma-separated) is empty.     |
+
+```go
+type Payment struct {
+    Type    string `json:"type"`
+    Card    string `json:"card"    requiredIf:"Type card"`
+    Pass    string `json:"pass"`
+    Confirm string `json:"confirm" requiredWith:"Pass"`
+    Email   string `json:"email"`
+    Phone   string `json:"phone"   requiredWithout:"Email"`
+}
+```
+
+### Schema Annotations
+
+These emit OpenAPI schema keywords and are documentation-only (no runtime enforcement).
+
+| Tag                | Description                                                        |
+|--------------------|-------------------------------------------------------------------|
+| `readOnly:"true"`  | Marks the property `readOnly` (returned but not sent by clients). |
+| `writeOnly:"true"` | Marks the property `writeOnly` (sent but not returned).           |
+| `nullable:"true"`  | Marks the property as `nullable`. Pointer fields are nullable automatically. |
 
 
 
@@ -74,6 +107,9 @@ fields (and each element of `[]string` fields).
 | `semver`        | `format:"semver"`       | Semantic version (e.g. `1.2.3-alpha.1`).                  |
 | `json-pointer`  | `format:"json-pointer"` | JSON Pointer (RFC 6901).                                   |
 | `byte` / `base64`| `format:"byte"`        | Base64-encoded value.                                     |
+| `base64url`     | `format:"base64url"`    | URL-safe Base64 (padded or unpadded).                     |
+| `jwt`           | `format:"jwt"`          | JSON Web Token (three base64url segments).                |
+| `port`          | `format:"port"`         | TCP/UDP port number (`1`–`65535`).                        |
 
 #### String content
 
@@ -87,6 +123,15 @@ fields (and each element of `[]string` fields).
 | `uppercase`    | `format:"uppercase"`    | No lowercase characters.                            |
 | `slug`         | `format:"slug"`         | URL slug (e.g. `my-post-123`).                     |
 | `hexcolor`     | `format:"hexcolor"`     | Hex color (`#RGB` or `#RRGGBB`).                   |
+| `json`         | `format:"json"`         | A syntactically valid JSON string.                  |
+
+#### Geo & time zones
+
+| Format      | Tag                  | Description                                          |
+|-------------|----------------------|-----------------------------------------------------|
+| `latitude`  | `format:"latitude"`  | Decimal latitude in the range `-90` to `90`.       |
+| `longitude` | `format:"longitude"` | Decimal longitude in the range `-180` to `180`.    |
+| `timezone`  | `format:"timezone"`  | IANA time zone name (e.g. `America/New_York`).     |
 
 #### Custom pattern
 

--- a/okapi.go
+++ b/okapi.go
@@ -1154,20 +1154,24 @@ func (o *Okapi) Any(path string, h HandlerFunc, opts ...RouteOption) *Route {
 // Static serves static files under a path prefix, without directory listing
 func (o *Okapi) Static(prefix string, dir string) {
 	fs := http.StripPrefix(prefix, http.FileServer(noDirListing{http.Dir(dir)}))
-	o.router.muxRouter.PathPrefix(prefix).Handler(fs).Methods(http.MethodGet)
+	o.router.muxRouter.PathPrefix(prefix).
+		HandlerFunc(o.dispatchThroughChain(fs.ServeHTTP)).
+		Methods(http.MethodGet)
 }
 
 // StaticFile serves a single file at the specified path.
 func (o *Okapi) StaticFile(path string, filepath string) {
-	o.router.muxRouter.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+	o.router.muxRouter.HandleFunc(path, o.dispatchThroughChain(func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, filepath)
-	}).Methods(http.MethodGet)
+	})).Methods(http.MethodGet)
 }
 
 // StaticFS serves static files from a custom http.FileSystem (e.g., embed.FS).
 func (o *Okapi) StaticFS(prefix string, fs http.FileSystem) {
 	fileServer := http.StripPrefix(prefix, http.FileServer(fs))
-	o.router.muxRouter.PathPrefix(prefix).Handler(fileServer).Methods(http.MethodGet)
+	o.router.muxRouter.PathPrefix(prefix).
+		HandlerFunc(o.dispatchThroughChain(fileServer.ServeHTTP)).
+		Methods(http.MethodGet)
 }
 
 // addRoute adds a route with the specified method to the Okapi instance
@@ -1517,6 +1521,31 @@ func buildBaseLogFields(c *Context, status int, duration time.Duration) []any {
 		"user_agent", c.request.UserAgent(),
 	}
 }
+
+// dispatchThroughChain wraps a raw http.HandlerFunc so it runs through Okapi's
+// global middleware chain (access log, debug fields, and any user-registered
+// global middleware) via a Context, mirroring how regular routes are
+// dispatched.
+func (o *Okapi) dispatchThroughChain(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := NewContext(o, w, r)
+		global := o.globalMiddlewares()
+		handlers := make([]HandlerFunc, 0, len(global)+1)
+		handlers = append(handlers, global...)
+		handlers = append(handlers, func(c *Context) error {
+			next(c.response, c.request)
+			return nil
+		})
+		ctx.handlers = handlers
+		ctx.index = -1
+		if err := ctx.Next(); err != nil {
+			if ctx.response.StatusCode() == 0 {
+				http.Error(ctx.response, err.Error(), http.StatusInternalServerError)
+			}
+		}
+	}
+}
+
 func (o *Okapi) wrapHandleFunc(h HandlerFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := NewContext(o, w, r)

--- a/openapi.go
+++ b/openapi.go
@@ -1794,6 +1794,16 @@ func applyValidationTags(schema *openapi3.Schema, tag reflect.StructTag) {
 		}
 		schema.Extensions[extOkapiConst] = constVal
 	}
+	// Schema annotations mapped directly to OpenAPI keywords.
+	if tag.Get(tagReadOnly) == constTRUE {
+		schema.ReadOnly = true
+	}
+	if tag.Get(tagWriteOnly) == constTRUE {
+		schema.WriteOnly = true
+	}
+	if tag.Get(tagNullable) == constTRUE {
+		schema.Nullable = true
+	}
 }
 
 // applyStringSchemaTags applies minLength, maxLength, pattern, and format.

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -536,3 +536,38 @@ func TestOpenAPIValidationKeywords(t *testing.T) {
 	validateOpenAPIDoc(t, spec30)
 	validateOpenAPIDoc(t, spec31)
 }
+
+// schemaAnnotationModel exercises the readOnly, writeOnly, and nullable tags.
+type schemaAnnotationModel struct {
+	ID       string `json:"id" readOnly:"true"`
+	Password string `json:"password" writeOnly:"true"`
+	Nickname string `json:"nickname" nullable:"true"`
+}
+
+func TestOpenAPISchemaAnnotations(t *testing.T) {
+	o := New()
+	o.WithOpenAPIDocs(OpenAPI{
+		Title:   "Schema Annotations",
+		Version: "1.0.0",
+		License: License{Name: "MIT"},
+		Servers: Servers{{URL: "http://localhost:8080"}},
+	})
+	o.Post("/things", anyHandler,
+		DocRequestBody(&schemaAnnotationModel{}),
+		DocResponse(200, &schemaAnnotationModel{}),
+	)
+	o.buildOpenAPISpec()
+
+	spec30 := o.openapiSpec
+	spec31 := o.openapiSpec31
+
+	m30 := spec30.Components.Schemas["schemaAnnotationModel"].Value
+	require.NotNil(t, m30)
+
+	assert.True(t, m30.Properties["id"].Value.ReadOnly)
+	assert.True(t, m30.Properties["password"].Value.WriteOnly)
+	assert.True(t, m30.Properties["nickname"].Value.Nullable)
+
+	validateOpenAPIDoc(t, spec30)
+	validateOpenAPIDoc(t, spec31)
+}

--- a/static.go
+++ b/static.go
@@ -184,7 +184,7 @@ func (o *Okapi) webHandler(prefix string, root http.FileSystem, c WebConfig) {
 		serveWebIndex(w, r, root, c.Index)
 	}
 	o.router.muxRouter.PathPrefix(prefix).
-		HandlerFunc(handler).
+		HandlerFunc(o.dispatchThroughChain(handler)).
 		Methods(http.MethodGet, http.MethodHead)
 }
 

--- a/static_test.go
+++ b/static_test.go
@@ -3,6 +3,7 @@ package okapi
 import (
 	"bytes"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -39,6 +40,38 @@ func serveSPARequest(o *Okapi, target string) *httptest.ResponseRecorder {
 	rec := httptest.NewRecorder()
 	o.ServeHTTP(rec, req)
 	return rec
+}
+
+func TestWebRoutesFlowThroughAccessLog(t *testing.T) {
+	dir := writeSPAFixture(t)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	o := New()
+	o.WithLogger(logger)
+	o.Static("/static", dir)
+	o.Web("/", dir)
+
+	// Real asset served by Web, a Web index fallback, and a Static file should
+	// all produce an access log entry, just like regular routes.
+	cases := []struct {
+		name, target string
+	}{
+		{"web asset", "/assets/app.js"},
+		{"web index fallback", "/login"},
+		{"static file", "/static/favicon.ico"},
+	}
+	for _, tc := range cases {
+		buf.Reset()
+		rec := serveSPARequest(o, tc.target)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: status = %d, want 200", tc.name, rec.Code)
+		}
+		if !strings.Contains(buf.String(), "[okapi] Incoming request") {
+			t.Fatalf("%s: expected access log entry, got %q", tc.name, buf.String())
+		}
+	}
 }
 
 func TestSPAServesRealFile(t *testing.T) {

--- a/validator.go
+++ b/validator.go
@@ -26,6 +26,7 @@ package okapi
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"math"
 	"net"
@@ -64,7 +65,7 @@ func (c *Context) bindStruct(input any) error {
 		}
 
 		// Handle validations
-		if err := c.validateField(field, sf); err != nil {
+		if err := c.validateField(v, field, sf); err != nil {
 			return err
 		}
 	}
@@ -161,6 +162,7 @@ var fieldConstraintCheckers = []func(reflect.Value, reflect.StructField) error{
 	checkChoiceConstraints,
 	checkFormatConstraints,
 	checkCollectionConstraints,
+	checkSubstringConstraints,
 }
 
 // checkNumericConstraints validates min, max, exclusiveMin, exclusiveMax, and multipleOf.
@@ -272,10 +274,99 @@ func checkCollectionConstraints(field reflect.Value, sf reflect.StructField) err
 	return nil
 }
 
+// checkSubstringConstraints validates contains and notContains (both handle slices element-wise).
+func checkSubstringConstraints(field reflect.Value, sf reflect.StructField) error {
+	if tag := sf.Tag.Get(tagContains); tag != "" {
+		if err := checkContains(field, tag, true); err != nil {
+			return err
+		}
+	}
+	if tag := sf.Tag.Get(tagNotContains); tag != "" {
+		if err := checkContains(field, tag, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkContains asserts a string field contains (want=true) or does not contain
+// (want=false) the given substring. For slice fields, each element is validated.
+func checkContains(field reflect.Value, substr string, want bool) error {
+	if field.Kind() == reflect.Slice {
+		for i := 0; i < field.Len(); i++ {
+			if err := checkContainsValue(field.Index(i), substr, want); err != nil {
+				return fmt.Errorf("element [%d]: %w", i, err)
+			}
+		}
+		return nil
+	}
+	return checkContainsValue(field, substr, want)
+}
+
+func checkContainsValue(field reflect.Value, substr string, want bool) error {
+	if field.Kind() != reflect.String {
+		return fmt.Errorf("contains validation can only be applied to string fields")
+	}
+	value := field.String()
+	if value == "" {
+		return nil
+	}
+	if got := strings.Contains(value, substr); got != want {
+		if want {
+			return fmt.Errorf("value '%s' must contain '%s'", value, substr)
+		}
+		return fmt.Errorf("value '%s' must not contain '%s'", value, substr)
+	}
+	return nil
+}
+
+// checkConditionalRequired reports whether a requiredIf, requiredWith, or
+// requiredWithout rule on the field is triggered while the field is empty.
+// structVal is the parent struct so sibling fields can be resolved by name.
+func checkConditionalRequired(structVal, field reflect.Value, sf reflect.StructField) bool {
+	required := false
+
+	if tag := sf.Tag.Get(tagRequiredIf); tag != "" {
+		name, want, ok := strings.Cut(strings.TrimSpace(tag), " ")
+		if ok {
+			if sibling := structVal.FieldByName(name); sibling.IsValid() {
+				if fmt.Sprintf("%v", sibling.Interface()) == strings.TrimSpace(want) {
+					required = true
+				}
+			}
+		}
+	}
+
+	if tag := sf.Tag.Get(tagRequiredWith); tag != "" {
+		for _, name := range strings.Split(tag, ",") {
+			sibling := structVal.FieldByName(strings.TrimSpace(name))
+			if sibling.IsValid() && !isEmptyValue(sibling) {
+				required = true
+				break
+			}
+		}
+	}
+
+	if tag := sf.Tag.Get(tagRequiredWithout); tag != "" {
+		for _, name := range strings.Split(tag, ",") {
+			sibling := structVal.FieldByName(strings.TrimSpace(name))
+			if !sibling.IsValid() || isEmptyValue(sibling) {
+				required = true
+				break
+			}
+		}
+	}
+
+	return required && isEmptyValue(field)
+}
+
 // validateField performs tag-based validations: required, min/max, length constraints,
 // enum, const, multipleOf, format, pattern, and slice/map validations.
-func (c *Context) validateField(field reflect.Value, sf reflect.StructField) error {
+func (c *Context) validateField(structVal, field reflect.Value, sf reflect.StructField) error {
 	if sf.Tag.Get(tagRequired) == constTRUE && isEmptyValue(field) {
+		return fmt.Errorf("field %s is required", sf.Name)
+	}
+	if checkConditionalRequired(structVal, field, sf) {
 		return fmt.Errorf("field %s is required", sf.Name)
 	}
 	for _, check := range fieldConstraintCheckers {
@@ -295,6 +386,9 @@ func (c *Context) validateStruct(v reflect.Value, parentField reflect.StructFiel
 		sf := t.Field(i)
 
 		if sf.Tag.Get(tagRequired) == constTRUE && isEmptyValue(field) {
+			return fmt.Errorf("field %s.%s is required", parentField.Name, sf.Name)
+		}
+		if checkConditionalRequired(v, field, sf) {
 			return fmt.Errorf("field %s.%s is required", parentField.Name, sf.Name)
 		}
 		for _, check := range fieldConstraintCheckers {
@@ -557,6 +651,13 @@ var formatValidators = map[string]func(string) error{
 	formatUppercase:    validateUppercase,
 	formatSlug:         validateSlug,
 	formatHexColor:     validateHexColor,
+	formatJSON:         validateJSON,
+	formatJWT:          validateJWT,
+	formatBase64URL:    validateBase64URL,
+	formatPort:         validatePort,
+	formatTimezone:     validateTimezone,
+	formatLatitude:     validateLatitude,
+	formatLongitude:    validateLongitude,
 }
 
 // checkFormatValue validates a single value against a format tag
@@ -1060,6 +1161,83 @@ func validateSlug(value string) error {
 func validateHexColor(value string) error {
 	if !hexColorRegex.MatchString(value) {
 		return fmt.Errorf("invalid hex color (expected #RGB or #RRGGBB): %s", value)
+	}
+	return nil
+}
+
+func validateJSON(value string) error {
+	if !json.Valid([]byte(value)) {
+		return fmt.Errorf("invalid JSON: %s", value)
+	}
+	return nil
+}
+
+// validateJWT checks for three non-empty base64url segments (header.payload.signature).
+func validateJWT(value string) error {
+	parts := strings.Split(value, ".")
+	if len(parts) != 3 {
+		return fmt.Errorf("invalid JWT (expected 3 segments): %s", value)
+	}
+	// Header and payload must be non-empty base64url; signature may be empty (e.g. alg=none).
+	for _, p := range parts[:2] {
+		if p == "" {
+			return fmt.Errorf("invalid JWT (empty segment): %s", value)
+		}
+	}
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		if _, err := base64.RawURLEncoding.DecodeString(p); err != nil {
+			return fmt.Errorf("invalid JWT (segment is not base64url): %s", value)
+		}
+	}
+	return nil
+}
+
+// validateBase64URL accepts both padded and unpadded URL-safe base64.
+func validateBase64URL(value string) error {
+	if _, err := base64.URLEncoding.DecodeString(value); err == nil {
+		return nil
+	}
+	if _, err := base64.RawURLEncoding.DecodeString(value); err == nil {
+		return nil
+	}
+	return fmt.Errorf("invalid base64url value: %s", value)
+}
+
+func validatePort(value string) error {
+	n, err := strconv.Atoi(value)
+	if err != nil || n < 1 || n > 65535 {
+		return fmt.Errorf("invalid port (expected 1-65535): %s", value)
+	}
+	return nil
+}
+
+func validateTimezone(value string) error {
+	// LoadLocation treats "" as UTC and "Local" as the host zone, neither of which
+	// is a meaningful IANA name to validate against.
+	if value == "" || value == "Local" {
+		return fmt.Errorf("invalid timezone (expected IANA name, e.g. America/New_York): %s", value)
+	}
+	if _, err := time.LoadLocation(value); err != nil {
+		return fmt.Errorf("invalid timezone (expected IANA name, e.g. America/New_York): %s", value)
+	}
+	return nil
+}
+
+func validateLatitude(value string) error {
+	f, err := strconv.ParseFloat(value, 64)
+	if err != nil || f < -90 || f > 90 {
+		return fmt.Errorf("invalid latitude (expected -90 to 90): %s", value)
+	}
+	return nil
+}
+
+func validateLongitude(value string) error {
+	f, err := strconv.ParseFloat(value, 64)
+	if err != nil || f < -180 || f > 180 {
+		return fmt.Errorf("invalid longitude (expected -180 to 180): %s", value)
 	}
 	return nil
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -1601,3 +1601,199 @@ func TestTier1ValidationIntegration(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"valid object", `{"a":1}`, false},
+		{"valid array", `[1,2,3]`, false},
+		{"valid string", `"hello"`, false},
+		{"valid number", `42`, false},
+		{"invalid trailing", `{"a":1}x`, true},
+		{"invalid unclosed", `{"a":`, true},
+		{"not json", `hello`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateJSON(tt.value); (err != nil) != tt.wantErr {
+				t.Errorf("validateJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateJWT(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"valid", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.c2ln", false},
+		{"valid empty signature", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.", false},
+		{"two segments", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ", true},
+		{"empty header", ".eyJzdWIiOiIxMjMifQ.c2ln", true},
+		{"non base64url segment", "not_base64!.payload.sig", true},
+		{"four segments", "a.b.c.d", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateJWT(tt.value); (err != nil) != tt.wantErr {
+				t.Errorf("validateJWT() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateBase64URL(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"padded", "Zm9vYmFy", false},
+		{"url-safe chars", "a-b_cd", false},
+		{"unpadded", "Zm9vYg", false},
+		{"standard base64 with plus", "a+b/c=", true},
+		{"invalid char", "not base64!", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateBase64URL(tt.value); (err != nil) != tt.wantErr {
+				t.Errorf("validateBase64URL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidatePort(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"min", "1", false},
+		{"max", "65535", false},
+		{"typical", "8080", false},
+		{"zero", "0", true},
+		{"too high", "65536", true},
+		{"negative", "-1", true},
+		{"not a number", "http", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validatePort(tt.value); (err != nil) != tt.wantErr {
+				t.Errorf("validatePort() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateTimezone(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"iana", "America/New_York", false},
+		{"utc", "UTC", false},
+		{"empty", "", true},
+		{"local", "Local", true},
+		{"bogus", "Mars/Phobos", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateTimezone(tt.value); (err != nil) != tt.wantErr {
+				t.Errorf("validateTimezone() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateLatitudeLongitude(t *testing.T) {
+	if err := validateLatitude("45.5"); err != nil {
+		t.Errorf("validateLatitude(45.5) unexpected error: %v", err)
+	}
+	if err := validateLatitude("91"); err == nil {
+		t.Error("validateLatitude(91) expected error")
+	}
+	if err := validateLongitude("-179.9"); err != nil {
+		t.Errorf("validateLongitude(-179.9) unexpected error: %v", err)
+	}
+	if err := validateLongitude("181"); err == nil {
+		t.Error("validateLongitude(181) expected error")
+	}
+}
+
+func TestContainsValidation(t *testing.T) {
+	type Req struct {
+		Path  string `json:"path" contains:"/"`
+		Token string `json:"token" notContains:" "`
+	}
+	tests := []struct {
+		name        string
+		body        string
+		wantErr     bool
+		errContains string
+	}{
+		{"valid", `{"path":"/a/b","token":"abc"}`, false, ""},
+		{"missing substring", `{"path":"noslash","token":"abc"}`, true, "must contain '/'"},
+		{"forbidden substring", `{"path":"/a","token":"a b"}`, true, "must not contain"},
+		{"empty optional skipped", `{}`, false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := NewTestContext(http.MethodPost, "/test", strings.NewReader(tt.body))
+			c.request.Header.Set("Content-Type", "application/json")
+			var req Req
+			err := c.Bind(&req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Bind() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.errContains != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("Bind() error = %v, should contain %q", err, tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestConditionalRequiredValidation(t *testing.T) {
+	type Req struct {
+		Type    string `json:"type"`
+		Card    string `json:"card" requiredIf:"Type card"`
+		Pass    string `json:"pass"`
+		Confirm string `json:"confirm" requiredWith:"Pass"`
+		Email   string `json:"email"`
+		Phone   string `json:"phone" requiredWithout:"Email"`
+	}
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{"requiredIf triggered and missing", `{"type":"card","email":"a@b.co"}`, true},
+		{"requiredIf triggered and present", `{"type":"card","card":"4111","email":"a@b.co"}`, false},
+		{"requiredIf not triggered", `{"type":"cash","email":"a@b.co"}`, false},
+		{"requiredWith triggered and missing", `{"pass":"secret","email":"a@b.co"}`, true},
+		{"requiredWith triggered and present", `{"pass":"secret","confirm":"secret","email":"a@b.co"}`, false},
+		{"requiredWithout triggered and missing", `{}`, true},
+		{"requiredWithout satisfied by sibling", `{"email":"a@b.co"}`, false},
+		{"requiredWithout satisfied by self", `{"phone":"+123"}`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := NewTestContext(http.MethodPost, "/test", strings.NewReader(tt.body))
+			c.request.Header.Set("Content-Type", "application/json")
+			var req Req
+			err := c.Bind(&req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Bind() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
feat(static): route Web and Static handlers through middleware chain
Web, WebFS, Static, StaticFile, and StaticFS registered their handlers
directly on the mux router, bypassing Okapi's global middleware chain.